### PR TITLE
Add test case for streets starting with numbers and houseNr postfix

### DIFF
--- a/tests/AddressSplitterTest.php
+++ b/tests/AddressSplitterTest.php
@@ -403,6 +403,19 @@ class AddressSplitterTest extends \PHPUnit_Framework_TestCase
                     'additionToAddress2' => 'WG2'
                 )
             ),
+            array(
+                '1e Loosterweg 14',
+                array(
+                    'additionToAddress1' => '',
+                    'streetName'         => '1e Loosterweg',
+                    'houseNumber'        => '14',
+                    'houseNumberParts'   => array(
+                        'base' => '14',
+                        'extension' => ''
+                    ),
+                    'additionToAddress2' => ''
+                )
+            ),
         );
     }
 


### PR DESCRIPTION
This adds a failing test-case for a real-world situation where an
address format with a post-fix house number has a street name
that starts with a digit.

I can only think of two ways to properly fix this, both of which
would be breaking changes.

1. Throw a new exception type containing both matches if they
   both match and let the API consumer pick which one they want.
2. Add an optional parameter for country, store a list of which
   country uses which format, and use the format belonging to the
   country when there's a conflict.

I vote for 2, with a fallback to 1 if no country is available