### PR TITLE
Support house numbers with fractions in it (e.g. Poststr. 2 1/2)

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,6 +74,7 @@ Here is a number of examples of addresses and how their splitted representation 
 |Kerkstraat 13-HS                             |                    |Kerkstraat              |13-HS        | 13   | HS        |                    |
 |Poststr. 15-WG2                              |                    |Poststr.                |15           | 15   |           |                    |
 |Hollandweg1A                                 |                    |Hollandweg              |1A           | 1    | A         |                    |
+|Poststr. 2 1/2                               |                    |Poststr.                |2 1/2        | 2 1/2|           |                    |
 
 
 ## Unit Tests

--- a/src/AddressSplitter.php
+++ b/src/AddressSplitter.php
@@ -31,7 +31,7 @@ class AddressSplitter
             (?:No\.\s*)?
                 (?P<A_House_number_match>
                      (?P<A_House_number_base>
-                        \pN+(\s+\d\/\d)?
+                        \pN+(\s+\d+\/\d+)?
                      )
                      (?:
                         \s*[\-\/\.]?\s*
@@ -52,7 +52,7 @@ class AddressSplitter
             \s*[\/,]?\s*(?:\sNo[.:])?\s*
                 (?P<B_House_number_match>
                      (?P<B_House_number_base>
-                        \pN+(\s+\d\/\d)?
+                        \pN+(\s+\d+\/\d+)?
                      )
                      (?:
                         (?:

--- a/src/AddressSplitter.php
+++ b/src/AddressSplitter.php
@@ -31,7 +31,7 @@ class AddressSplitter
             (?:No\.\s*)?
                 (?P<A_House_number_match>
                      (?P<A_House_number_base>
-                        \pN+
+                        \pN+(\s+\d\/\d)?
                      )
                      (?:
                         \s*[\-\/\.]?\s*
@@ -52,7 +52,7 @@ class AddressSplitter
             \s*[\/,]?\s*(?:\sNo[.:])?\s*
                 (?P<B_House_number_match>
                      (?P<B_House_number_base>
-                        \pN+
+                        \pN+(\s+\d\/\d)?
                      )
                      (?:
                         (?:

--- a/tests/AddressSplitterTest.php
+++ b/tests/AddressSplitterTest.php
@@ -403,6 +403,19 @@ class AddressSplitterTest extends \PHPUnit_Framework_TestCase
                     'additionToAddress2' => 'WG2'
                 )
             ),
+            array(
+                'Reitelbauerstr. 7 1/2',
+                array(
+                    'additionToAddress1' => '',
+                    'streetName'         => 'Reitelbauerstr.',
+                    'houseNumber'        => '7 1/2',
+                    'houseNumberParts'   => array(
+                        'base' => '7 1/2',
+                        'extension' => ''
+                    ),
+                    'additionToAddress2' => ''
+                )
+            )
         );
     }
 


### PR DESCRIPTION
Some German addresses have house numbers like Poststr. 2 1/2. This adds support for the fraction in it.