### PR TITLE
Support location-specifying additions to address (e.g., "Haus 4", "8th floor", …)

### DIFF
--- a/src/AddressSplitter.php
+++ b/src/AddressSplitter.php
@@ -54,6 +54,21 @@ class AddressSplitter
             | \s+ (?: WG | W\.G\. | WG\. | Wohngemeinschaft ) ($ | \s)
             | \s+ (?: [Aa]partment | APT \.? | Apt \.? ) \s
             | \s+ (?: [Ff]lat ) \s
+            | (?: # Numeric-based location specifiers (e.g., "3. Stock"):
+                \s+
+                (?:
+                    [\p{N}]+ # A number, …
+                    (?i: st | nd | rd | th)? # …, optionally followed by an English number suffix
+                    \.? # …, followed by an optional dot,
+                    \s* # …, followed by optional spacing
+                )?
+                (?: # Specifying category:
+                    (?i: Stock | Stockwerk)
+                    | App \.? | Apt \.? | (?i: Appartment | Apartment)
+                )
+                # At the end of the string or followed by a space
+                (?: $ | \s)
+            )
             | (?:
                 \s+ (?:
                     # English language stop words wrt location from source [1]

--- a/src/AddressSplitter.php
+++ b/src/AddressSplitter.php
@@ -22,8 +22,16 @@ class AddressSplitter
     public static function splitAddress($address)
     {
         /* Matching this group signifies the following text is part of
-         * additionToAddress2. */
+         * additionToAddress2.
+         *
+         * See [1] for some of the English language stop words and abbreviations.
+         *
+         * [1] <https://web.archive.org/web/20180410130330/http://maf.directory/zp4/abbrev.html>
+         */
         $addition2Introducers = '(?:
+
+            # {{{ Additions relating to who (a natural person) is addressed
+
             \s+ [Cc] \s* \/ \s* [Oo] \s
             | ℅
             | \s+ care \s+ of \s+
@@ -38,6 +46,91 @@ class AddressSplitter
                 (?: V | V.\s* | (?<=\s)Vertreter\s+ )
                 (?: i | i.\s* | (?<=\s)im\s+ )
                 (?: A | A.\s* | (?<=\s)Amt\s+ )
+
+            # }}}
+            # {{{ Additions which further specify more precisely the location
+
+            | \s+ (?: Haus ) \s
+            | \s+ (?: WG | W\.G\. | WG\. | Wohngemeinschaft ) ($ | \s)
+            | \s+ (?: [Aa]partment | APT \.? | Apt \.? ) \s
+            | \s+ (?: [Ff]lat ) \s
+            | (?:
+                \s+ (?:
+                    # English language stop words wrt location from source [1]
+                    # (extracted only those which may not be _exclusively_ part of
+                    # street names):
+                    | ANX \.? | (?i: ANNEX)
+                    | APT \.? | (?i: APARTMENT)
+                    | ARC \.? | (?i: ARCADE)
+                    | AVE \.? | (?i: AVENUE)
+                    | BSMT \.? | (?i: BASEMENT)
+                    | BLDG \.? | (?i: BUILDING)
+                    | CP \.? | (?i: CAMP)
+                    | COR \.? | (?i: CORNER)
+                    | CORS \.? | (?i: CORNERS)
+                    | CT \.? | (?i: COURT)
+                    | CTS \.? | (?i: COURTS)
+                    | DEPT \.? | (?i: DEPARTMENT)
+                    | DV \.? | (?i: DIVIDE)
+                    | EST \.? | (?i: ESTATE)
+                    | EXT \.? | (?i: EXTENSION)
+                    | FRY \.? | (?i: FERRY)
+                    | FLD \.? | (?i: FIELD)
+                    | FLDS \.? | (?i: FIELDS)
+                    | FLT \.? | (?i: FLAT)
+                    | FL \.? | (?i: FLOOR)
+                    | FRNT \.? | (?i: FRONT)
+                    | GDNS \.? | (?i: GARDEN)
+                    | GDNS \.? | (?i: GARDENS)
+                    | GTWY \.? | (?i: GATEWAY)
+                    | GRN \.? | (?i: GREEN)
+                    | GRV \.? | (?i: GROVE)
+                    | HNGR \.? | (?i: HANGER)
+                    | HBR \.? | (?i: HARBOR)
+                    | HVN \.? | (?i: HAVEN)
+                    | KY \.? | (?i: KEY)
+                    | LBBY \.? | (?i: LOBBY)
+                    | LCKS \.? | (?i: LOCK)
+                    | LCKS \.? | (?i: LOCKS)
+                    | LDG \.? | (?i: LODGE)
+                    | MNR \.? | (?i: MANOR)
+                    | OFC \.? | (?i: OFFICE)
+                    | PKWY \.? | (?i: PARKWAY)
+                    | PH \.? | (?i: PENTHOUSE)
+                    | PRT \.? | (?i: PORT)
+                    | RADL \.? | (?i: RADIAL)
+                    | RM \.? | (?i: ROOM)
+                    | SPC \.? | (?i: SPACE)
+                    | SQ \.? | (?i: SQUARE)
+                    | STA \.? | (?i: STATION)
+                    | STE \.? | (?i: SUITE)
+                    | TER \.? | (?i: TERRACE)
+                    | TRAK \.? | (?i: TRACK)
+                    | TRL \.? | (?i: TRAIL)
+                    | TRLR \.? | (?i: TRAILER)
+                    | TUNL \.? | (?i: TUNNEL)
+                    | VW \.? | (?i: VIEW)
+                    | VIS \.? | (?i: VISTA)
+
+                    # Custom custom additions:
+                    | (?i: Story | Storey)
+                    | LVL \.? | (?i: Level)
+                )
+                # May optionally be followed directly by a number+letter
+                # combination (e.g., "LVL3C"):
+                (?: [\p{N}]+[\p{L}]* )?
+                # Occurs at the end of the string or followed by a space:
+                ($ | \s)
+            )
+
+            # Heuristic to match location specifiers. These must not be
+            # conflated with house number extensions as in "12 AB". Hence
+            # our heuristic is at least 3 letters with the first letter being
+            # spelled as a capital. E.g., it would match "Haus", "Gebäude" or
+            # "Arbeitspl.", but not "AAB".
+            | \s+ ( [\p{Lu}\p{Lt}] [\p{Ll}\p{Lo}]{2,}  \.? ) ($ | \s)
+
+            # }}}
         )';
 
         $regex = '

--- a/tests/AddressSplitterTest.php
+++ b/tests/AddressSplitterTest.php
@@ -520,6 +520,84 @@ class AddressSplitterTest extends \PHPUnit_Framework_TestCase
                     'additionToAddress2' => '℅ West Area Computing'
                 )
             ),
+            array(
+                'Hauptstraße 27 Haus 1',
+                array(
+                    'additionToAddress1' => '',
+                    'streetName'         => 'Hauptstraße',
+                    'houseNumber'        => '27',
+                    'houseNumberParts'   => array(
+                        'base' => '27',
+                        'extension' => ''
+                    ),
+                    'additionToAddress2' => 'Haus 1'
+                )
+            ),
+            array(
+                'Rosentiefe 13 A Skulptur 5',
+                array(
+                    'additionToAddress1' => '',
+                    'streetName'         => 'Rosentiefe',
+                    'houseNumber'        => '13 A',
+                    'houseNumberParts'   => array(
+                        'base' => '13',
+                        'extension' => 'A'
+                    ),
+                    'additionToAddress2' => 'Skulptur 5'
+                )
+            ),
+            array(
+                'Torwolds Road 123 APT 3',
+                array(
+                    'additionToAddress1' => '',
+                    'streetName'         => 'Torwolds Road',
+                    'houseNumber'        => '123',
+                    'houseNumberParts'   => array(
+                        'base' => '123',
+                        'extension' => ''
+                    ),
+                    'additionToAddress2' => 'APT 3'
+                )
+            ),
+            array(
+                'Denis Ritchie Road 3 Building C',
+                array(
+                    'additionToAddress1' => '',
+                    'streetName'         => 'Denis Ritchie Road',
+                    'houseNumber'        => '3',
+                    'houseNumberParts'   => array(
+                        'base' => '3',
+                        'extension' => ''
+                    ),
+                    'additionToAddress2' => 'Building C'
+                )
+            ),
+            array(
+                'Brian-Kernighan-Straße 3 LVL3C',
+                array(
+                    'additionToAddress1' => '',
+                    'streetName'         => 'Brian-Kernighan-Straße',
+                    'houseNumber'        => '3',
+                    'houseNumberParts'   => array(
+                        'base' => '3',
+                        'extension' => ''
+                    ),
+                    'additionToAddress2' => 'LVL3C'
+                )
+            ),
+            array(
+                'Brian-Kernighan-Straße 3 LVL3C Zimmer 12',
+                array(
+                    'additionToAddress1' => '',
+                    'streetName'         => 'Brian-Kernighan-Straße',
+                    'houseNumber'        => '3',
+                    'houseNumberParts'   => array(
+                        'base' => '3',
+                        'extension' => ''
+                    ),
+                    'additionToAddress2' => 'LVL3C Zimmer 12'
+                )
+            )
         );
     }
 

--- a/tests/AddressSplitterTest.php
+++ b/tests/AddressSplitterTest.php
@@ -597,6 +597,32 @@ class AddressSplitterTest extends \PHPUnit_Framework_TestCase
                     ),
                     'additionToAddress2' => 'LVL3C Zimmer 12'
                 )
+            ),
+            array(
+                'Brian-Kernighan-Straße 3 B 8. Stock App. C',
+                array(
+                    'additionToAddress1' => '',
+                    'streetName'         => 'Brian-Kernighan-Straße',
+                    'houseNumber'        => '3 B',
+                    'houseNumberParts'   => array(
+                        'base' => '3',
+                        'extension' => 'B'
+                    ),
+                    'additionToAddress2' => '8. Stock App. C'
+                )
+            ),
+            array(
+                'Brian-Kernighan-Straße 3 B 8th Floor App. C',
+                array(
+                    'additionToAddress1' => '',
+                    'streetName'         => 'Brian-Kernighan-Straße',
+                    'houseNumber'        => '3 B',
+                    'houseNumberParts'   => array(
+                        'base' => '3',
+                        'extension' => 'B'
+                    ),
+                    'additionToAddress2' => '8th Floor App. C'
+                )
             )
         );
     }


### PR DESCRIPTION
Originally proposed by @windaishi in https://github.com/VIISON/AddressSplitting/commit/b1e2121d7a38c465a17ef23d3b9191cdfcf65e8e (https://github.com/VIISON/AddressSplitting/compare/windaishi/another-tricky-address-format).

Note: _Separate commits: Do not squash_